### PR TITLE
Escape output file with quotes

### DIFF
--- a/index.js
+++ b/index.js
@@ -73,7 +73,7 @@ PDFImage.prototype = {
   },
   constructConvertCommandForPage: function (pageNumber) {
     var pdfFilePath = this.pdfFilePath;
-    var outputImagePath = this.getOutputImagePathForPage(pageNumber);
+    var outputImagePath = "\""+this.getOutputImagePathForPage(pageNumber)+"\"";
     var convertOptionsString = this.constructConvertOptions();
     return util.format(
       "convert %s'%s[%d]' %s",


### PR DESCRIPTION
ImageMagick will not properly handle filenames with spaces if not escaped by quotes.