### PR TITLE
fix element id in command

### DIFF
--- a/index.js
+++ b/index.js
@@ -86,7 +86,7 @@ PDFImage.prototype = {
   constructConvertOptions: function () {
     return Object.keys(this.convertOptions).sort().map(function (optionName) {
       if (this.convertOptions[optionName] !== null) {
-        return optionName + " " + this.convertOptions[optionName];
+        return this.convertOptions[optionName];
       } else {
         return optionName;
       }


### PR DESCRIPTION
I maybe didn't understand exactly this extra piece of code.

Anyway it create command such as:
`convert 0 -density 1 400 2 -colorspace 3 RGB 4 -resize 5 2331 [...]`
when using you code with:
`pdfImage.setConvertOptions(["-density", "400", "-colorspace", "RGB", "-resize", "2331"]);`

It now works for me on MacOSX.