### PR TITLE
set output directory customisable

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,8 +17,7 @@ function PDFImage(pdfFilePath, options) {
   this.setConvertExtension(options.convertExtension);
   this.useGM = options.graphicsMagick || false;
 
-  // TODO: make out dir customizable
-  this.outputDirectory = path.dirname(pdfFilePath);
+  this.outputDirectory = options.outputDirectory || path.dirname(pdfFilePath);
 }
 
 PDFImage.prototype = {


### PR DESCRIPTION
Output directory for images can be set with :

var pdfimage = new PDFImage('/tmp/file.pdf', {
  outputDirectory: '/tmp/filepages/'
});
