### PR TITLE
Add setPdfFileBaseName

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,8 +11,8 @@ function PDFImage(pdfFilePath, options) {
   if (!options) options = {};
 
   this.pdfFilePath = pdfFilePath;
-  this.pdfFileBaseName = options.pdfFileBaseName || path.basename(pdfFilePath, ".pdf");
 
+  this.setPdfFileBaseName(options.pdfFileBaseName);
   this.setConvertOptions(options.convertOptions);
   this.setConvertExtension(options.convertExtension);
   this.useGM = options.graphicsMagick || false;
@@ -67,6 +67,9 @@ PDFImage.prototype = {
   },
   setConvertOptions: function (convertOptions) {
     this.convertOptions = convertOptions || {};
+  },
+  setPdfFileBaseName: function(pdfFileBaseName) {
+    this.pdfFileBaseName = pdfFileBaseName || path.basename(this.pdfFilePath, ".pdf");
   },
   setConvertExtension: function (convertExtension) {
     this.convertExtension = convertExtension || "png";

--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ function PDFImage(pdfFilePath, options) {
   if (!options) options = {};
 
   this.pdfFilePath = pdfFilePath;
-  this.pdfFileBaseName = path.basename(pdfFilePath, ".pdf");
+  this.pdfFileBaseName = options.pdfFileBaseName || path.basename(pdfFilePath, ".pdf");
 
   this.setConvertOptions(options.convertOptions);
   this.setConvertExtension(options.convertExtension);

--- a/tests/test-main.js
+++ b/tests/test-main.js
@@ -16,6 +16,11 @@ describe("PDFImage", function () {
   it("should have correct basename", function () {
     expect(pdfImage.pdfFileBaseName).equal("test");
   });
+  
+  it("should set custom basename", function() {
+    pdfImage.setPdfFileBaseName('custom-basename');
+    expect(pdfImage.pdfFileBaseName).equal("custom-basename");
+  });
 
   it("should return correct page path", function () {
     expect(pdfImage.getOutputImagePathForPage(1))


### PR DESCRIPTION
Allow customizable pdfFileBaseName for control over outputImagePath. Great for when not writing file to disk locally and tmp file is used for image conversion.
