### PR TITLE
Add non-zero based numbering for page paths.

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,6 +18,7 @@ function PDFImage(pdfFilePath, options) {
   this.useGM = options.graphicsMagick || false;
 
   this.outputDirectory = options.outputDirectory || path.dirname(pdfFilePath);
+  this.nonZeroBased = options.nonZeroBased || false;
 }
 
 PDFImage.prototype = {
@@ -60,9 +61,12 @@ PDFImage.prototype = {
     });
   },
   getOutputImagePathForPage: function (pageNumber) {
+    var fileName = this.pdfFileBaseName
+          + "-" + ((this.nonZeroBased) ? (~~pageNumber+1) : pageNumber)
+          + "." + this.convertExtension;
     return path.join(
       this.outputDirectory,
-      this.pdfFileBaseName + "-" + pageNumber + "." + this.convertExtension
+      fileName
     );
   },
   setConvertOptions: function (convertOptions) {

--- a/tests/test-main.js
+++ b/tests/test-main.js
@@ -26,6 +26,14 @@ describe("PDFImage", function () {
       .equal("/tmp/test-1000.png");
   });
 
+  it("should return non-zero based page path", function () {
+    pdfImage = new PDFImage(pdfPath, { nonZeroBased: true });
+    expect(pdfImage.getOutputImagePathForPage(0))
+      .equal("/tmp/test-1.png");
+    expect(pdfImage.getOutputImagePathForPage(2))
+      .equal("/tmp/test-3.png");
+  });
+
   it("should return correct convert command", function () {
     expect(pdfImage.constructConvertCommandForPage(1))
       .equal("convert '/tmp/test.pdf[1]' '/tmp/test-1.png'");


### PR DESCRIPTION
Found myself wanting output to be non-zero based numbering in custom "convertAllPages" script.
Only affects output image path. So ```convertPage(0)``` would write ```tmp/test-1.png``` in example. Defaults to original zero-based numbering.