### PR TITLE
Throw error if pdfImage.numberOfPages() fails

### DIFF
--- a/index.js
+++ b/index.js
@@ -157,7 +157,9 @@ PDFImage.prototype = {
         }).catch(function(error){
           reject(error);
         });
-      });
+      }).catch((error) => {
+          reject(error);
+        });
     });
   },
   convertPage: function (pageNumber) {


### PR DESCRIPTION
Before, numberOfPages() failed silently if the tool "pdfinfo" was not installed.
This change simplifies debugging for anyone who did not install the external tools before executing pdfImage.convertFile().