### PR TITLE
fix combinedImage with file paths with spaces

### DIFF
--- a/index.js
+++ b/index.js
@@ -72,6 +72,11 @@ PDFImage.prototype = {
       this.pdfFileBaseName + "." + this.convertExtension
     );
   },
+  getEscapedFilePaths: function (filePaths) {
+    return filePaths.map(path =>
+      path.replace(/ /g, "\\ ")
+    ).join(' ')
+  },
   setConvertOptions: function (convertOptions) {
     this.convertOptions = convertOptions || {};
   },
@@ -96,7 +101,7 @@ PDFImage.prototype = {
     return util.format(
       "%s -append %s \"%s\"",
       this.useGM ? "gm convert" : "convert",
-      imagePaths.join(' '),
+      this.getEscapedFilePaths(imagePaths),
       this.getOutputImagePathForFile()
     );
   },


### PR DESCRIPTION
I got an uncaught error when trying to convert pdf to png. The pdf file path has some spaces and I figured that the command `convert -append file with spaces.png "combinedImage.png"` was the caused, and it was.

The solution involves adding the necessary espaced spaces in the command such that a line becomes
`convert -append file\ with\ spaces.png "combinedImage.png"`.

Please code review this PR, and merge if you consider it useful.